### PR TITLE
Int session duration

### DIFF
--- a/aws_adfs/login.py
+++ b/aws_adfs/login.py
@@ -163,7 +163,7 @@ def login(
         RoleArn=config.role_arn,
         PrincipalArn=principal_arn,
         SAMLAssertion=assertion,
-        DurationSeconds=config.session_duration,
+        DurationSeconds=int(config.session_duration),
     )
 
     if stdout:


### PR DESCRIPTION
Running the login after the session duration is in the config boto will crash without the cast.